### PR TITLE
Formatting and Saving Forecast Data with Tests

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,7 +8,6 @@ on:
     - cron: "0 12 * * 1"
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
-
 jobs:
   call-run-python-tests:
     uses: openclimatefix/.github/.github/workflows/python-test.yml@issue/pip-all
@@ -18,8 +17,3 @@ jobs:
       os_list: '["ubuntu-latest"]'
       python-version: "['3.11']"
       pytest_numcpus: '1'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Install dependencies
-        run: pip install .[dev]  # Install with dev dependencies

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,6 +8,7 @@ on:
     - cron: "0 12 * * 1"
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
+
 jobs:
   call-run-python-tests:
     uses: openclimatefix/.github/.github/workflows/python-test.yml@issue/pip-all
@@ -17,3 +18,8 @@ jobs:
       os_list: '["ubuntu-latest"]'
       python-version: "['3.11']"
       pytest_numcpus: '1'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: pip install .[dev]  # Install with dev dependencies

--- a/neso_solar_consumer/fetch_data.py
+++ b/neso_solar_consumer/fetch_data.py
@@ -8,9 +8,7 @@ import json
 import pandas as pd
 
 
-def fetch_data(
-    resource_id: str, limit: int, columns: list, rename_columns: dict
-) -> pd.DataFrame:
+def fetch_data(resource_id: str, limit: int, columns: list, rename_columns: dict) -> pd.DataFrame:
     """
     Fetch data from the NESO API and process it into a Pandas DataFrame.
 
@@ -55,9 +53,7 @@ def fetch_data(
         return pd.DataFrame()
 
 
-def fetch_data_using_sql(
-    sql_query: str, columns: list, rename_columns: dict
-) -> pd.DataFrame:
+def fetch_data_using_sql(sql_query: str, columns: list, rename_columns: dict) -> pd.DataFrame:
     """
     Fetch data from the NESO API using an SQL query, process it, and return specific columns with renamed headers.
 

--- a/neso_solar_consumer/format_forecast.py
+++ b/neso_solar_consumer/format_forecast.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timezone
+import pandas as pd
+from nowcasting_datamodel.models import ForecastSQL, ForecastValue
+from nowcasting_datamodel.read.read import get_latest_input_data_last_updated, get_location
+from nowcasting_datamodel.read.read_models import get_model
+
+
+def format_to_forecast_sql(data: pd.DataFrame, model_tag: str, model_version: str, session) -> list:
+    """
+    Convert fetched NESO solar data into ForecastSQL objects.
+
+    Parameters:
+        data (pd.DataFrame): The input DataFrame with solar forecast data.
+        model_tag (str): The name/tag of the model.
+        model_version (str): The version of the model.
+        session (Session): SQLAlchemy session for database access.
+
+    Returns:
+        list: A list of ForecastSQL objects.
+    """
+    # Get the model object
+    model = get_model(name=model_tag, version=model_version, session=session)
+
+    # Fetch the last updated input data timestamp
+    input_data_last_updated = get_latest_input_data_last_updated(session=session)
+
+    forecasts = []
+    for _, row in data.iterrows():
+        if pd.isnull(row["start_utc"]) or pd.isnull(row["solar_forecast_kw"]):
+            continue  # Skip rows with missing critical data
+
+        # Convert "start_utc" to a datetime object
+        target_time = datetime.fromisoformat(row["start_utc"]).replace(tzinfo=timezone.utc)
+
+        forecast_values = [
+            ForecastValue(
+                target_time=target_time,
+                expected_power_generation_megawatts=row["solar_forecast_kw"]
+            ).to_orm()
+        ]
+
+        location = get_location(session=session, gsp_id=row.get("gsp_id", 0))
+
+        forecast = ForecastSQL(
+            model=model,
+            forecast_creation_time=datetime.now(tz=timezone.utc),
+            location=location,
+            input_data_last_updated=input_data_last_updated,
+            forecast_values=forecast_values,
+            historic=False,
+        )
+
+        forecasts.append(forecast)
+
+    return forecasts

--- a/neso_solar_consumer/format_forecast.py
+++ b/neso_solar_consumer/format_forecast.py
@@ -67,9 +67,5 @@ def format_to_forecast_sql(data: pd.DataFrame, model_tag: str, model_version: st
     )
     logger.debug(f"ForecastSQL Object Created: {forecast}")
 
-    # Step 6: Add to session and flush
-    session.add(forecast)
-    session.flush()
     logger.info("ForecastSQL object successfully added to session and flushed.")
-
     return [forecast]

--- a/neso_solar_consumer/format_forecast.py
+++ b/neso_solar_consumer/format_forecast.py
@@ -35,7 +35,7 @@ def format_to_forecast_sql(data: pd.DataFrame, model_tag: str, model_version: st
         forecast_values = [
             ForecastValue(
                 target_time=target_time,
-                expected_power_generation_megawatts=row["solar_forecast_kw"]
+                expected_power_generation_megawatts=row["solar_forecast_kw"],
             ).to_orm()
         ]
 

--- a/neso_solar_consumer/save_forecasts.py
+++ b/neso_solar_consumer/save_forecasts.py
@@ -2,6 +2,7 @@
 
 from nowcasting_datamodel.save.save import save
 
+
 def save_forecasts_to_db(forecasts: list, session):
     """
     Save a list of ForecastSQL objects to the database using the nowcasting_datamodel `save` function.

--- a/neso_solar_consumer/save_forecasts.py
+++ b/neso_solar_consumer/save_forecasts.py
@@ -1,0 +1,17 @@
+# save_forecasts.py
+
+from nowcasting_datamodel.save.save import save
+
+def save_forecasts_to_db(forecasts: list, session):
+    """
+    Save a list of ForecastSQL objects to the database using the nowcasting_datamodel `save` function.
+
+    Parameters:
+        forecasts (list): The list of ForecastSQL objects to save.
+        session (Session): SQLAlchemy session for database access.
+    """
+    save(
+        forecasts=forecasts,
+        session=session,
+        save_to_last_seven_days=True,  # Save forecasts to the last seven days table
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,5 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest","black","ruff"
+    "pytest","black","ruff","sqlalchemy"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "neso_solar_consumer"
 version = "0.1"
 dependencies = [
-    "pandas","sqlalchemy"
+    "pandas","sqlalchemy","nowcasting_datamodel"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "neso_solar_consumer"
 version = "0.1"
 dependencies = [
-    "pandas","sqlalchemy","nowcasting_datamodel"
+    "pandas","sqlalchemy","nowcasting_datamodel","testcontainers"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ build-backend = "setuptools.build_meta"
 name = "neso_solar_consumer"
 version = "0.1"
 dependencies = [
-    "pandas"
+    "pandas","sqlalchemy"
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest","black","ruff","sqlalchemy"
+    "pytest", "black", "ruff"
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,72 @@
+import pytest
+from typing import Generator
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from nowcasting_datamodel.models.base import Base_Forecast
+from nowcasting_datamodel.models import MLModelSQL
+
+# Shared Test Configuration Constants
+TEST_DB_URL = "postgresql://postgres:12345@localhost/testdb"
+RESOURCE_ID = "db6c038f-98af-4570-ab60-24d71ebd0ae5"
+LIMIT = 5
+COLUMNS = ["DATE_GMT", "TIME_GMT", "EMBEDDED_SOLAR_FORECAST"]
+RENAME_COLUMNS = {
+    "DATE_GMT": "start_utc",
+    "TIME_GMT": "end_utc",
+    "EMBEDDED_SOLAR_FORECAST": "solar_forecast_kw",
+}
+MODEL_NAME = "real_data_model"
+MODEL_VERSION = "1.0"
+
+
+@pytest.fixture(scope="function")
+def db_session() -> Generator:
+    """
+    Fixture to set up and tear down a PostgreSQL database session for testing.
+
+    This fixture:
+    - Creates a fresh database schema before each test.
+    - Adds a dummy ML model for test purposes.
+    - Tears down the database session and cleans up resources after each test.
+
+    Returns:
+        Generator: A SQLAlchemy session object.
+    """
+    # Create database engine and tables
+    engine = create_engine(TEST_DB_URL)
+    Base_Forecast.metadata.drop_all(engine)  # Drop all tables to ensure a clean slate
+    Base_Forecast.metadata.create_all(engine)  # Recreate the tables
+
+    # Establish session
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    # Insert a dummy model for testing
+    session.query(MLModelSQL).delete()  # Clean up any pre-existing data
+    model = MLModelSQL(name=MODEL_NAME, version=MODEL_VERSION)
+    session.add(model)
+    session.commit()
+
+    yield session  # Provide the session to the test
+
+    # Cleanup: close session and dispose of engine
+    session.close()
+    engine.dispose()
+
+
+@pytest.fixture(scope="session")
+def test_config():
+    """
+    Fixture to provide shared test configuration constants.
+
+    Returns:
+        dict: A dictionary of test configuration values.
+    """
+    return {
+        "resource_id": RESOURCE_ID,
+        "limit": LIMIT,
+        "columns": COLUMNS,
+        "rename_columns": RENAME_COLUMNS,
+        "model_name": MODEL_NAME,
+        "model_version": MODEL_VERSION,
+    }

--- a/tests/test_fetch_data.py
+++ b/tests/test_fetch_data.py
@@ -1,3 +1,30 @@
+"""
+Test Suite for `fetch_data` and `fetch_data_using_sql` Functions
+
+This script contains tests to validate the functionality and consistency of two data-fetching functions: 
+`fetch_data` (via API) and `fetch_data_using_sql` (via SQL query). It checks that the data returned 
+by both methods is correctly processed, contains the expected columns, and ensures the consistency 
+between the two methods.
+
+### How to Run the Tests:
+
+You can run the entire suite of tests in this file using `pytest` from the command line:
+   
+    pytest tests/test_fetch_data.py
+
+To run a specific test, you can specify the function name:
+
+    pytest tests/test_fetch_data.py::test_fetch_data_api
+
+For verbose output, use the -v flag:
+
+    pytest tests/test_fetch_data.py -v
+
+To run tests matching a specific pattern, use the -k option:
+
+    pytest tests/test_fetch_data.py -k "fetch_data"
+
+"""
 from neso_solar_consumer.fetch_data import fetch_data, fetch_data_using_sql
 
 

--- a/tests/test_fetch_data.py
+++ b/tests/test_fetch_data.py
@@ -1,72 +1,44 @@
-"""
-Test Suite for `fetch_data` and `fetch_data_using_sql` Functions
-
-This script contains tests to validate the functionality and consistency of two data-fetching functions: 
-`fetch_data` (via API) and `fetch_data_using_sql` (via SQL query). It checks that the data returned 
-by both methods is correctly processed, contains the expected columns, and ensures the consistency 
-between the two methods.
-
-### How to Run the Tests:
-
-You can run the entire suite of tests in this file using `pytest` from the command line:
-   
-    pytest tests/test_fetch_data.py
-
-To run a specific test, you can specify the function name:
-
-    pytest tests/test_fetch_data.py::test_fetch_data_api
-
-For verbose output, use the -v flag:
-
-    pytest tests/test_fetch_data.py -v
-
-To run tests matching a specific pattern, use the -k option:
-
-    pytest tests/test_fetch_data.py -k "fetch_data"
-
-"""
-
-import pytest  # noqa: F401
 from neso_solar_consumer.fetch_data import fetch_data, fetch_data_using_sql
 
 
-resource_id = "db6c038f-98af-4570-ab60-24d71ebd0ae5"
-limit = 5
-columns = ["DATE_GMT", "TIME_GMT", "EMBEDDED_SOLAR_FORECAST"]
-rename_columns = {
-    "DATE_GMT": "start_utc",
-    "TIME_GMT": "end_utc",
-    "EMBEDDED_SOLAR_FORECAST": "solar_forecast_kw",
-}
-sql_query = f'SELECT * from "{resource_id}" LIMIT {limit}'
-
-
-def test_fetch_data_api():
+def test_fetch_data_api(test_config):
     """
     Test the fetch_data function to ensure it fetches and processes data correctly via API.
     """
-    df_api = fetch_data(resource_id, limit, columns, rename_columns)
+    df_api = fetch_data(
+        test_config["resource_id"],
+        test_config["limit"],
+        test_config["columns"],
+        test_config["rename_columns"],
+    )
     assert not df_api.empty, "fetch_data returned an empty DataFrame!"
     assert set(df_api.columns) == set(
-        rename_columns.values()
+        test_config["rename_columns"].values()
     ), "Column names do not match after renaming!"
 
 
-def test_fetch_data_sql():
+def test_fetch_data_sql(test_config):
     """
     Test the fetch_data_using_sql function to ensure it fetches and processes data correctly via SQL.
     """
-    df_sql = fetch_data_using_sql(sql_query, columns, rename_columns)
+    sql_query = f'SELECT * FROM "{test_config["resource_id"]}" LIMIT {test_config["limit"]}'
+    df_sql = fetch_data_using_sql(sql_query, test_config["columns"], test_config["rename_columns"])
     assert not df_sql.empty, "fetch_data_using_sql returned an empty DataFrame!"
     assert set(df_sql.columns) == set(
-        rename_columns.values()
+        test_config["rename_columns"].values()
     ), "Column names do not match after renaming!"
 
 
-def test_data_consistency():
+def test_data_consistency(test_config):
     """
     Validate that the data fetched by fetch_data and fetch_data_using_sql are consistent.
     """
-    df_api = fetch_data(resource_id, limit, columns, rename_columns)
-    df_sql = fetch_data_using_sql(sql_query, columns, rename_columns)
+    sql_query = f'SELECT * FROM "{test_config["resource_id"]}" LIMIT {test_config["limit"]}'
+    df_api = fetch_data(
+        test_config["resource_id"],
+        test_config["limit"],
+        test_config["columns"],
+        test_config["rename_columns"],
+    )
+    df_sql = fetch_data_using_sql(sql_query, test_config["columns"], test_config["rename_columns"])
     assert df_api.equals(df_sql), "Data from fetch_data and fetch_data_using_sql are inconsistent!"

--- a/tests/test_fetch_data.py
+++ b/tests/test_fetch_data.py
@@ -26,7 +26,7 @@ To run tests matching a specific pattern, use the -k option:
 
 """
 
-import pytest
+import pytest  # noqa: F401
 from neso_solar_consumer.fetch_data import fetch_data, fetch_data_using_sql
 
 
@@ -69,6 +69,4 @@ def test_data_consistency():
     """
     df_api = fetch_data(resource_id, limit, columns, rename_columns)
     df_sql = fetch_data_using_sql(sql_query, columns, rename_columns)
-    assert df_api.equals(
-        df_sql
-    ), "Data from fetch_data and fetch_data_using_sql are inconsistent!"
+    assert df_api.equals(df_sql), "Data from fetch_data and fetch_data_using_sql are inconsistent!"

--- a/tests/test_format_forecast.py
+++ b/tests/test_format_forecast.py
@@ -1,0 +1,94 @@
+"""
+Test Suite for `format_to_forecast_sql` Function
+
+This script validates the functionality of the `format_to_forecast_sql` function.
+It checks if the function correctly converts the input data into SQLAlchemy-compatible
+ForecastSQL objects.
+
+### How to Run the Tests:
+
+You can run the entire suite of tests in this file using `pytest` from the command line:
+   
+    pytest tests/test_format_forecast.py
+
+To run a specific test, you can specify the function name:
+
+    pytest tests/test_format_forecast.py::test_format_to_forecast_sql_real
+
+For verbose output, use the -v flag:
+
+    pytest tests/test_format_forecast.py -v
+
+To run tests matching a specific pattern, use the -k option:
+
+    pytest tests/test_format_forecast.py -k "format_to_forecast_sql"
+
+"""
+
+import pytest
+from typing import Generator
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from nowcasting_datamodel.models.base import Base_Forecast
+from nowcasting_datamodel.models import MLModelSQL
+from neso_solar_consumer.fetch_data import fetch_data
+from neso_solar_consumer.format_forecast import format_to_forecast_sql
+
+# Test configuration
+RESOURCE_ID = "db6c038f-98af-4570-ab60-24d71ebd0ae5"
+LIMIT = 5
+COLUMNS = ["DATE_GMT", "TIME_GMT", "EMBEDDED_SOLAR_FORECAST"]
+RENAME_COLUMNS = {
+    "DATE_GMT": "start_utc",
+    "TIME_GMT": "end_utc",
+    "EMBEDDED_SOLAR_FORECAST": "solar_forecast_kw",
+}
+MODEL_NAME = "real_data_model"
+MODEL_VERSION = "1.0"
+
+
+@pytest.fixture
+def db_session() -> Generator:
+    """
+    Create a PostgreSQL database session for testing.
+
+    Returns:
+        Generator: A session object to interact with the database.
+    """
+    engine = create_engine("postgresql://postgres:12345@localhost/testdb")
+    Base_Forecast.metadata.create_all(engine)  # Create tables
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    # Add a dummy model entry for the test
+    model = MLModelSQL(name=MODEL_NAME, version=MODEL_VERSION)
+    session.add(model)
+    session.commit()
+
+    yield session
+
+    session.close()
+    engine.dispose()
+
+
+def test_format_to_forecast_sql_real(db_session):
+    """
+    Test `format_to_forecast_sql` with real data fetched from NESO API.
+
+    Steps:
+    1. Fetch data from the NESO API.
+    2. Convert the data to ForecastSQL objects using `format_to_forecast_sql`.
+    3. Validate the number of generated forecasts matches the input data.
+    4. Verify that the model metadata (name, version) is correctly assigned.
+    """
+    # Fetch data
+    data = fetch_data(RESOURCE_ID, LIMIT, COLUMNS, RENAME_COLUMNS)
+    assert not data.empty, "fetch_data returned an empty DataFrame!"
+
+    # Format data to ForecastSQL objects
+    forecasts = format_to_forecast_sql(data, MODEL_NAME, MODEL_VERSION, db_session)
+
+    # Assertions
+    assert len(forecasts) == len(data), "Mismatch in number of forecasts and data rows!"
+    assert forecasts[0].model.name == MODEL_NAME, "Model name does not match!"
+    assert forecasts[0].model.version == MODEL_VERSION, "Model version does not match!"

--- a/tests/test_format_forecast.py
+++ b/tests/test_format_forecast.py
@@ -2,27 +2,27 @@
 Test Suite for `format_to_forecast_sql` Function
 
 This script validates the functionality of the `format_to_forecast_sql` function.
-It checks if the function correctly converts the input data into SQLAlchemy-compatible
-ForecastSQL objects.
+It ensures that the function correctly creates a single ForecastSQL object with multiple
+ForecastValue entries.
 
 ### How to Run the Tests:
 
-You can run the entire suite of tests in this file using `pytest` from the command line:
-   
+Run the entire suite:
     pytest tests/test_format_forecast.py
 
-To run a specific test, you can specify the function name:
-
+Run a specific test:
     pytest tests/test_format_forecast.py::test_format_to_forecast_sql_real
 
-For verbose output, use the -v flag:
-
+For verbose output:
     pytest tests/test_format_forecast.py -v
 
-To run tests matching a specific pattern, use the -k option:
+Note: 
+This test assumes a local PostgreSQL database configured with:
+    - Username: `postgres`
+    - Password: `12345`
+    - Database: `testdb`
 
-    pytest tests/test_format_forecast.py -k "format_to_forecast_sql"
-
+This setup is temporary for local testing and may require adjustment for CI/CD environments.
 """
 
 import pytest
@@ -30,11 +30,11 @@ from typing import Generator
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from nowcasting_datamodel.models.base import Base_Forecast
-from nowcasting_datamodel.models import MLModelSQL
+from nowcasting_datamodel.models import MLModelSQL, ForecastSQL, ForecastValue
 from neso_solar_consumer.fetch_data import fetch_data
 from neso_solar_consumer.format_forecast import format_to_forecast_sql
 
-# Test configuration
+# Test configuration constants
 RESOURCE_ID = "db6c038f-98af-4570-ab60-24d71ebd0ae5"
 LIMIT = 5
 COLUMNS = ["DATE_GMT", "TIME_GMT", "EMBEDDED_SOLAR_FORECAST"]
@@ -50,45 +50,84 @@ MODEL_VERSION = "1.0"
 @pytest.fixture
 def db_session() -> Generator:
     """
-    Create a PostgreSQL database session for testing.
+    Fixture to set up and tear down a PostgreSQL database session for testing.
 
-    Returns:
-        Generator: A session object to interact with the database.
+    Database connection details (modify if required):
+        - Host: localhost
+        - User: postgres
+        - Password: 12345
+        - Database: testdb
+
+    Creates fresh tables before each test and cleans up after execution.
     """
     engine = create_engine("postgresql://postgres:12345@localhost/testdb")
+    Base_Forecast.metadata.drop_all(engine)  # Drop tables if they already exist
     Base_Forecast.metadata.create_all(engine)  # Create tables
+
     Session = sessionmaker(bind=engine)
     session = Session()
 
-    # Add a dummy model entry for the test
+    # Add a dummy ML model for testing
+    session.query(MLModelSQL).delete()  # Ensure no pre-existing data
     model = MLModelSQL(name=MODEL_NAME, version=MODEL_VERSION)
     session.add(model)
     session.commit()
 
-    yield session
+    yield session  # Provide session to the test function
 
+    # Cleanup
     session.close()
     engine.dispose()
 
 
 def test_format_to_forecast_sql_real(db_session):
     """
-    Test `format_to_forecast_sql` with real data fetched from NESO API.
+    Test `format_to_forecast_sql` with real data fetched from the NESO API.
 
     Steps:
-    1. Fetch data from the NESO API.
-    2. Convert the data to ForecastSQL objects using `format_to_forecast_sql`.
-    3. Validate the number of generated forecasts matches the input data.
-    4. Verify that the model metadata (name, version) is correctly assigned.
+    1. Fetch test data from the NESO API.
+    2. Format the data into a ForecastSQL object using the target function.
+    3. Validate the creation of ForecastSQL and associated ForecastValue entries.
+    4. Verify database state for correctness.
+
+    Expected Outcomes:
+    - A single ForecastSQL object is created.
+    - The number of ForecastValue entries matches the input data.
+    - The model metadata (name, version) matches the expected values.
+    - No redundant or duplicate objects are added to the database.
     """
-    # Fetch data
+    # Step 1: Fetch mock data from the API
     data = fetch_data(RESOURCE_ID, LIMIT, COLUMNS, RENAME_COLUMNS)
     assert not data.empty, "fetch_data returned an empty DataFrame!"
 
-    # Format data to ForecastSQL objects
+    # Step 2: Format the data into a ForecastSQL object
     forecasts = format_to_forecast_sql(data, MODEL_NAME, MODEL_VERSION, db_session)
 
-    # Assertions
-    assert len(forecasts) == len(data), "Mismatch in number of forecasts and data rows!"
-    assert forecasts[0].model.name == MODEL_NAME, "Model name does not match!"
-    assert forecasts[0].model.version == MODEL_VERSION, "Model version does not match!"
+    # Step 3: Validate the ForecastSQL object
+    assert len(forecasts) == 1, "More than one ForecastSQL object was created!"
+    forecast = forecasts[0]
+
+    # Validate the number of ForecastValue entries
+    assert len(forecast.forecast_values) == len(data), (
+        f"Mismatch in the number of ForecastValue entries. "
+        f"Expected: {len(data)}, Got: {len(forecast.forecast_values)}"
+    )
+
+    # Step 4: Validate model metadata
+    assert forecast.model.name == MODEL_NAME, f"Model name mismatch. Expected: {MODEL_NAME}"
+    assert forecast.model.version == MODEL_VERSION, f"Model version mismatch. Expected: {MODEL_VERSION}"
+
+    # Step 5: Validate database state
+    forecasts_in_db = db_session.query(ForecastSQL).all()
+    assert len(forecasts_in_db) == 1, "Unexpected number of ForecastSQL objects in the database!"
+
+    total_forecast_values = db_session.query(ForecastValue).count()
+    assert total_forecast_values == len(data), (
+        f"Mismatch in the number of ForecastValue entries in the database. "
+        f"Expected: {len(data)}, Got: {total_forecast_values}"
+    )
+
+    # Debugging information for better visibility
+    print(f"ForecastSQL object created successfully with {len(forecast.forecast_values)} ForecastValues.")
+    print(f"Total ForecastSQL objects in database: {len(forecasts_in_db)}")
+    print(f"Total ForecastValue objects in database: {total_forecast_values}")

--- a/tests/test_format_forecast.py
+++ b/tests/test_format_forecast.py
@@ -1,133 +1,27 @@
-"""
-Test Suite for `format_to_forecast_sql` Function
-
-This script validates the functionality of the `format_to_forecast_sql` function.
-It ensures that the function correctly creates a single ForecastSQL object with multiple
-ForecastValue entries.
-
-### How to Run the Tests:
-
-Run the entire suite:
-    pytest tests/test_format_forecast.py
-
-Run a specific test:
-    pytest tests/test_format_forecast.py::test_format_to_forecast_sql_real
-
-For verbose output:
-    pytest tests/test_format_forecast.py -v
-
-Note: 
-This test assumes a local PostgreSQL database configured with:
-    - Username: `postgres`
-    - Password: `12345`
-    - Database: `testdb`
-
-This setup is temporary for local testing and may require adjustment for CI/CD environments.
-"""
-
-import pytest
-from typing import Generator
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from nowcasting_datamodel.models.base import Base_Forecast
-from nowcasting_datamodel.models import MLModelSQL, ForecastSQL, ForecastValue
 from neso_solar_consumer.fetch_data import fetch_data
 from neso_solar_consumer.format_forecast import format_to_forecast_sql
-
-# Test configuration constants
-RESOURCE_ID = "db6c038f-98af-4570-ab60-24d71ebd0ae5"
-LIMIT = 5
-COLUMNS = ["DATE_GMT", "TIME_GMT", "EMBEDDED_SOLAR_FORECAST"]
-RENAME_COLUMNS = {
-    "DATE_GMT": "start_utc",
-    "TIME_GMT": "end_utc",
-    "EMBEDDED_SOLAR_FORECAST": "solar_forecast_kw",
-}
-MODEL_NAME = "real_data_model"
-MODEL_VERSION = "1.0"
+from nowcasting_datamodel.models import ForecastSQL, ForecastValue
 
 
-@pytest.fixture
-def db_session() -> Generator:
-    """
-    Fixture to set up and tear down a PostgreSQL database session for testing.
-
-    Database connection details (modify if required):
-        - Host: localhost
-        - User: postgres
-        - Password: 12345
-        - Database: testdb
-
-    Creates fresh tables before each test and cleans up after execution.
-    """
-    engine = create_engine("postgresql://postgres:12345@localhost/testdb")
-    Base_Forecast.metadata.drop_all(engine)  # Drop tables if they already exist
-    Base_Forecast.metadata.create_all(engine)  # Create tables
-
-    Session = sessionmaker(bind=engine)
-    session = Session()
-
-    # Add a dummy ML model for testing
-    session.query(MLModelSQL).delete()  # Ensure no pre-existing data
-    model = MLModelSQL(name=MODEL_NAME, version=MODEL_VERSION)
-    session.add(model)
-    session.commit()
-
-    yield session  # Provide session to the test function
-
-    # Cleanup
-    session.close()
-    engine.dispose()
-
-
-def test_format_to_forecast_sql_real(db_session):
+def test_format_to_forecast_sql_real(db_session, test_config):
     """
     Test `format_to_forecast_sql` with real data fetched from the NESO API.
-
-    Steps:
-    1. Fetch test data from the NESO API.
-    2. Format the data into a ForecastSQL object using the target function.
-    3. Validate the creation of ForecastSQL and associated ForecastValue entries.
-    4. Verify database state for correctness.
-
-    Expected Outcomes:
-    - A single ForecastSQL object is created.
-    - The number of ForecastValue entries matches the input data.
-    - The model metadata (name, version) matches the expected values.
-    - No redundant or duplicate objects are added to the database.
     """
     # Step 1: Fetch mock data from the API
-    data = fetch_data(RESOURCE_ID, LIMIT, COLUMNS, RENAME_COLUMNS)
+    data = fetch_data(
+        test_config["resource_id"],
+        test_config["limit"],
+        test_config["columns"],
+        test_config["rename_columns"],
+    )
     assert not data.empty, "fetch_data returned an empty DataFrame!"
 
     # Step 2: Format the data into a ForecastSQL object
-    forecasts = format_to_forecast_sql(data, MODEL_NAME, MODEL_VERSION, db_session)
-
-    # Step 3: Validate the ForecastSQL object
+    forecasts = format_to_forecast_sql(
+        data, test_config["model_name"], test_config["model_version"], db_session
+    )
     assert len(forecasts) == 1, "More than one ForecastSQL object was created!"
+
+    # Step 3: Validate ForecastSQL content
     forecast = forecasts[0]
-
-    # Validate the number of ForecastValue entries
-    assert len(forecast.forecast_values) == len(data), (
-        f"Mismatch in the number of ForecastValue entries. "
-        f"Expected: {len(data)}, Got: {len(forecast.forecast_values)}"
-    )
-
-    # Step 4: Validate model metadata
-    assert forecast.model.name == MODEL_NAME, f"Model name mismatch. Expected: {MODEL_NAME}"
-    assert forecast.model.version == MODEL_VERSION, f"Model version mismatch. Expected: {MODEL_VERSION}"
-
-    # Step 5: Validate database state
-    forecasts_in_db = db_session.query(ForecastSQL).all()
-    assert len(forecasts_in_db) == 1, "Unexpected number of ForecastSQL objects in the database!"
-
-    total_forecast_values = db_session.query(ForecastValue).count()
-    assert total_forecast_values == len(data), (
-        f"Mismatch in the number of ForecastValue entries in the database. "
-        f"Expected: {len(data)}, Got: {total_forecast_values}"
-    )
-
-    # Debugging information for better visibility
-    print(f"ForecastSQL object created successfully with {len(forecast.forecast_values)} ForecastValues.")
-    print(f"Total ForecastSQL objects in database: {len(forecasts_in_db)}")
-    print(f"Total ForecastValue objects in database: {total_forecast_values}")
+    assert len(forecast.forecast_values) == len(data), "Mismatch in ForecastValue entries!"

--- a/tests/test_save_forecasts.py
+++ b/tests/test_save_forecasts.py
@@ -1,0 +1,72 @@
+"""
+Integration Test for Fetching, Formatting, and Saving Forecast Data
+
+This script validates the integration of fetching real data, formatting it into ForecastSQL objects,
+and saving it to the database.
+"""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from nowcasting_datamodel.models.base import Base_Forecast
+from nowcasting_datamodel.models import ForecastSQL
+from neso_solar_consumer.fetch_data import fetch_data
+from neso_solar_consumer.format_forecast import format_to_forecast_sql
+from neso_solar_consumer.save_forecasts import save_forecasts_to_db
+
+# Test configuration
+RESOURCE_ID = "db6c038f-98af-4570-ab60-24d71ebd0ae5"
+LIMIT = 5
+COLUMNS = ["DATE_GMT", "TIME_GMT", "EMBEDDED_SOLAR_FORECAST"]
+RENAME_COLUMNS = {
+    "DATE_GMT": "start_utc",
+    "TIME_GMT": "end_utc",
+    "EMBEDDED_SOLAR_FORECAST": "solar_forecast_kw",
+}
+MODEL_NAME = "real_data_model"
+MODEL_VERSION = "1.0"
+
+@pytest.fixture
+def db_session():
+    """
+    Create a PostgreSQL database session for testing.
+
+    Returns:
+        Generator: A session object to interact with the database.
+    """
+    engine = create_engine("postgresql://postgres:12345@localhost/testdb")
+    Base_Forecast.metadata.create_all(engine)  # Create tables
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    yield session
+
+    session.close()
+    engine.dispose()
+
+def test_save_real_forecasts(db_session):
+    """
+    Integration test: Fetch real data, format it into forecasts, and save to the database.
+
+    Steps:
+    1. Fetch real data from the NESO API.
+    2. Format the data into ForecastSQL objects.
+    3. Save the forecasts to the database.
+    4. Verify that the forecasts are correctly saved.
+    """
+    # Step 1: Fetch real data
+    df = fetch_data(RESOURCE_ID, LIMIT, COLUMNS, RENAME_COLUMNS)
+    assert not df.empty, "fetch_data returned an empty DataFrame!"
+
+    # Step 2: Format data into ForecastSQL objects
+    forecasts = format_to_forecast_sql(df, MODEL_NAME, MODEL_VERSION, db_session)
+    assert forecasts, "No forecasts were generated from the fetched data!"
+
+    # Step 3: Save forecasts to the database
+    save_forecasts_to_db(forecasts, db_session)
+
+    # Step 4: Verify forecasts are saved in the database
+    saved_forecast = db_session.query(ForecastSQL).first()
+    assert saved_forecast is not None, "No forecast was saved to the database!"
+    assert saved_forecast.model.name == MODEL_NAME, "Model name does not match!"
+    assert len(saved_forecast.forecast_values) > 0, "No forecast values were saved!"

--- a/tests/test_save_forecasts.py
+++ b/tests/test_save_forecasts.py
@@ -26,6 +26,7 @@ RENAME_COLUMNS = {
 MODEL_NAME = "real_data_model"
 MODEL_VERSION = "1.0"
 
+
 @pytest.fixture
 def db_session():
     """
@@ -43,6 +44,7 @@ def db_session():
 
     session.close()
     engine.dispose()
+
 
 def test_save_real_forecasts(db_session):
     """

--- a/tests/test_save_forecasts.py
+++ b/tests/test_save_forecasts.py
@@ -6,47 +6,13 @@ and saving it to the database.
 """
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from nowcasting_datamodel.models.base import Base_Forecast
 from nowcasting_datamodel.models import ForecastSQL
 from neso_solar_consumer.fetch_data import fetch_data
 from neso_solar_consumer.format_forecast import format_to_forecast_sql
 from neso_solar_consumer.save_forecasts import save_forecasts_to_db
 
-# Test configuration
-RESOURCE_ID = "db6c038f-98af-4570-ab60-24d71ebd0ae5"
-LIMIT = 5
-COLUMNS = ["DATE_GMT", "TIME_GMT", "EMBEDDED_SOLAR_FORECAST"]
-RENAME_COLUMNS = {
-    "DATE_GMT": "start_utc",
-    "TIME_GMT": "end_utc",
-    "EMBEDDED_SOLAR_FORECAST": "solar_forecast_kw",
-}
-MODEL_NAME = "real_data_model"
-MODEL_VERSION = "1.0"
 
-
-@pytest.fixture
-def db_session():
-    """
-    Create a PostgreSQL database session for testing.
-
-    Returns:
-        Generator: A session object to interact with the database.
-    """
-    engine = create_engine("postgresql://postgres:12345@localhost/testdb")
-    Base_Forecast.metadata.create_all(engine)  # Create tables
-    Session = sessionmaker(bind=engine)
-    session = Session()
-
-    yield session
-
-    session.close()
-    engine.dispose()
-
-
-def test_save_real_forecasts(db_session):
+def test_save_real_forecasts(db_session, test_config):
     """
     Integration test: Fetch real data, format it into forecasts, and save to the database.
 
@@ -57,11 +23,18 @@ def test_save_real_forecasts(db_session):
     4. Verify that the forecasts are correctly saved.
     """
     # Step 1: Fetch real data
-    df = fetch_data(RESOURCE_ID, LIMIT, COLUMNS, RENAME_COLUMNS)
+    df = fetch_data(
+        test_config["resource_id"],
+        test_config["limit"],
+        test_config["columns"],
+        test_config["rename_columns"],
+    )
     assert not df.empty, "fetch_data returned an empty DataFrame!"
 
     # Step 2: Format data into ForecastSQL objects
-    forecasts = format_to_forecast_sql(df, MODEL_NAME, MODEL_VERSION, db_session)
+    forecasts = format_to_forecast_sql(
+        df, test_config["model_name"], test_config["model_version"], db_session
+    )
     assert forecasts, "No forecasts were generated from the fetched data!"
 
     # Step 3: Save forecasts to the database
@@ -70,5 +43,9 @@ def test_save_real_forecasts(db_session):
     # Step 4: Verify forecasts are saved in the database
     saved_forecast = db_session.query(ForecastSQL).first()
     assert saved_forecast is not None, "No forecast was saved to the database!"
-    assert saved_forecast.model.name == MODEL_NAME, "Model name does not match!"
+    assert saved_forecast.model.name == test_config["model_name"], "Model name does not match!"
     assert len(saved_forecast.forecast_values) > 0, "No forecast values were saved!"
+
+    # Debugging Output (Optional)
+    print("Forecast successfully saved to the database.")
+    print(f"Number of forecast values: {len(saved_forecast.forecast_values)}")


### PR DESCRIPTION
# Pull Request

## Description

This pull request addresses the functionality required for:
- Formatting NESO solar forecast data into OCF-compatible Forecast objects.
- Saving formatted forecasts to the database.

It tackles the following issues:
- Fixes #4
- Fixes #5

Key changes include:
- Added `format_to_forecast_sql` to transform fetched forecast data into `ForecastSQL` objects.
- Implemented `save_forecasts_to_db` to persist these formatted forecasts in the database.

- Applied code formatting (Black) and addressed all linting issues (Ruff).

## How Has This Been Tested?

Tests were added for both:
1. Formatting function (`format_to_forecast_sql`).
2. Saving function (`save_forecasts_to_db`).

The tests verify:
- The correctness of data transformation and structure.
- The ability to save real forecast data into the database.

To reproduce:
1. Run `pytest tests/test_format_forecast.py` to validate the formatting logic.
2. Run `pytest tests/test_save_forecasts.py` to validate the saving logic.



## Checklist:

- [x] My code follows [[OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)](https://github.com/openclimatefix/.github/blob/main/coding_style.md).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and corrected any misspellings.

