### PR TITLE
Replace the `DATABASE_URL` env variable name to `DB_URL` to meet the standards.

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -53,6 +53,15 @@
       "contributions": [
         "test"
       ]
+    },
+    {
+      "login": "ManzoorAhmedShaikh",
+      "name": "Manzoor Ahmed Shaikh",
+      "avatar_url": "https://avatars.githubusercontent.com/u/110716002?v=4",
+      "profile": "https://github.com/ManzoorAhmedShaikh",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/neso_solar_consumer/app.py
+++ b/neso_solar_consumer/app.py
@@ -75,10 +75,10 @@ def app(db_url: str):
 
 if __name__ == "__main__":
     # Step 1: Fetch the database URL from the environment variable
-    db_url = os.getenv("DATABASE_URL")
+    db_url = os.getenv("DB_URL") # Change from "DATABASE_URL" to "DB_URL"
 
     if not db_url:
-        logger.error("DATABASE_URL environment variable is not set. Exiting.")
+        logger.error("DB_URL environment variable is not set. Exiting.")
         exit(1)
 
     # Step 2: Run the application


### PR DESCRIPTION
# Pull Request

## Description

I replace the name of the `DATABASE_URL` env variable to `DB_URL` as suggested in the #34 issue. It is because the other repos also follow the same naming convention.

## Fixes

The fix applied in the https://github.com/openclimatefix/neso-solar-consumer/blob/main/neso_solar_consumer/app.py#L78-L81 file where I have replaced the name of the environment variable to `DB_URL`. 

## How Has This Been Tested?

I simply test it out by setting some test value of the new environment variable `DB_URL` using the command:
```
export DB_URL='your_database_connection_string`
```
and run the `app.py` file to see if it raising any error related to `DB_URL` naming.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
